### PR TITLE
Update pending approvals filter and remove points guide

### DIFF
--- a/app/routes/mbo_routes.py
+++ b/app/routes/mbo_routes.py
@@ -403,14 +403,16 @@ def pending_approvals():
     # Get all pending MBOs - for managers, show all pending MBOs, not just team members
     if current_user.role == 'Manager':
         pending_mbos = MBO.query.filter(
-            MBO.approval_status == 'Pending Approval'
+            MBO.approval_status == 'Pending Approval',
+            MBO.progress_status == 'Finished'
         ).order_by(MBO.created_at.desc()).all()
     else:
         # Get all pending MBOs for team members
         team_member_ids = [member.id for member in current_user.team_members]
         pending_mbos = MBO.query.filter(
             MBO.user_id.in_(team_member_ids),
-            MBO.approval_status == 'Pending Approval'
+            MBO.approval_status == 'Pending Approval',
+            MBO.progress_status == 'Finished'
         ).order_by(MBO.created_at.desc()).all()
     
     return render_template('pending_approvals.html', mbos=pending_mbos)

--- a/app/templates/pending_approvals.html
+++ b/app/templates/pending_approvals.html
@@ -2,12 +2,6 @@
 {% block content %}
 <h1>Pending MBOs</h1>
 
-<div class="info-box" style="background-color: #e7f5ff; border-left: 4px solid #0046ad; padding: 15px; margin-bottom: 25px; border-radius: 4px;">
-  <h3 style="margin-top: 0; color: #0046ad;">MBO Points Guide</h3>
-  <p style="margin-bottom: 5px;">• Standard MBO: 10 points for 100% completion</p>
-  <p style="margin-bottom: 5px;">• Exceptional Achievement: Up to 15 points (150%)</p>
-  <p style="margin-bottom: 0;">• Points are awarded quarterly and contribute to the engineer's performance evaluation</p>
-</div>
 
 {% if mbos %}
 <div style="overflow-x: auto;">


### PR DESCRIPTION
## Summary
- Modified pending approvals queries to only show MBOs that are both 'Pending Approval' AND 'Finished'
- Removed MBO Points Guide info box from the pending approvals template

## Changes
- Updated both Manager and team member queries in `app/routes/mbo_routes.py` to include `MBO.progress_status == 'Finished'` filter
- Removed the points guide section from `app/templates/pending_approvals.html`

## Test plan
- [ ] Verify pending approvals page only shows MBOs with status 'Finished' and 'Pending Approval'
- [ ] Confirm the points guide no longer appears on the pending approvals page
- [ ] Test with both Manager and non-Manager accounts

🤖 Generated with [Claude Code](https://claude.ai/code)